### PR TITLE
add install-d-locally to index file

### DIFF
--- a/welcome/index.yml
+++ b/welcome/index.yml
@@ -1,3 +1,4 @@
 title: Benvenuto
 ordering:
 - welcome-to-d
+- install-d-locally


### PR DESCRIPTION
Hey there,

I am testing auto-deploy of language submodules. Hence I will directly merge this.
If everything is setup correctly, this link should be working automatically:

http://tour.dlang.io/tour/it/welcome/install-d-locally

See also: https://github.com/stonemaster/dlang-tour/issues/460